### PR TITLE
Remove unreferenced sfne block

### DIFF
--- a/models/modules/__init__.py
+++ b/models/modules/__init__.py
@@ -1,5 +1,4 @@
 from .rgu import RGU
 from .g_ibs import G_IBS
 from .local_conv import LocalConv
-from .sfne_block import SFNEBlock
 from .linear import Linear1d, Linear2d


### PR DESCRIPTION
The SFNE block is unreferenced and throws errors when loading as a module. This removes the reference from __init__.py